### PR TITLE
Allowed for acquisition time to work with unordered inputs

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -131,10 +131,6 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
             groups[0].append(series_id)
             groups[1].append(len(mwgroup) - 1)
 
-        #if mw.dcm_data.InstanceNumber==1:
-        #    mwgroup_index = [g[1] for g in groups if g[0] == series_id][0]
-        #    mwgroup[mwgroup_index] = mw
-
     group_map = dict(zip(groups[0], groups[1]))
     
     total = 0

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -121,20 +121,29 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
                         series_id = series_id + (file_studyUID,)
                 groups[0].append(series_id)
                 groups[1].append(idx)
+                # ensure that the first image of every series is stored for seq_info
+                # needed for correct acquisition time
+                if mw.dcm_data.InstanceNumber==1:
+                    mwgroup[idx]=mw
 
         if not ingrp:
             mwgroup.append(mw)
             groups[0].append(series_id)
             groups[1].append(len(mwgroup) - 1)
 
-    group_map = dict(zip(groups[0], groups[1]))
+        #if mw.dcm_data.InstanceNumber==1:
+        #    mwgroup_index = [g[1] for g in groups if g[0] == series_id][0]
+        #    mwgroup[mwgroup_index] = mw
 
+    group_map = dict(zip(groups[0], groups[1]))
+    
     total = 0
     seqinfo = OrderedDict()
 
     # for the next line to make any sense the series_id needs to
     # be sortable in a way that preserves the series order
     for series_id, mwidx in sorted(group_map.items()):
+        
         if series_id[0] < 0:
             # skip our fake series with unwanted files
             continue
@@ -217,6 +226,7 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
             dcminfo.get('PatientSex'),
             dcminfo.get('AcquisitionDate'),
             dcminfo.get('AcquisitionTime'),
+            dcminfo.get('InstanceNumber')
         )
         # candidates
         # dcminfo.AccessionNumber

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -37,6 +37,7 @@ SeqInfo = namedtuple(
      'patient_sex',           # 23
      'date',                  # 24
      'acquisition_time',      # 25
+     'series_num',            # 26
      ]
 )
 


### PR DESCRIPTION
By grabbing InstanceNumber 1 for each dicom for seq_info the acquisition time will be correct when a tar file is used.